### PR TITLE
[#11] 게시글 수정 및 삭제 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.2'
     id 'io.spring.dependency-management' version '1.1.2'
+
+    id 'jacoco'
+
 }
 
 group = 'com'
@@ -46,6 +49,63 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
 }
 
-tasks.named('test') {
+
+test {
+    finalizedBy jacocoTestReport
     useJUnitPlatform()
+}
+
+
+jacoco {
+    toolVersion = "0.8.10"
+    reportsDirectory = layout.buildDirectory.dir('jacocoReport')
+}
+
+
+jacocoTestReport {
+
+    dependsOn test
+
+    reports {
+        xml.required = false
+        csv.required = false
+        html.required = true
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/domain/**',
+                            '**/global/**',
+                            '**/*Application*'
+                    ])
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true;
+            element = 'CLASS'
+
+            // 라인 커버리지 제한을 90%로 설정
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            excludes = [
+                    '**.*Application',
+                    '**.domain.**',
+                    '**.global.**'
+
+            ]
+        }
+
+    }
 }

--- a/src/main/java/com/wanted/controller/PostApiController.java
+++ b/src/main/java/com/wanted/controller/PostApiController.java
@@ -1,8 +1,6 @@
 package com.wanted.controller;
 
-import com.wanted.domain.post.dto.PostCreateRequest;
-import com.wanted.domain.post.dto.PostCreateResponse;
-import com.wanted.domain.post.dto.PostGetResponse;
+import com.wanted.domain.post.dto.*;
 import com.wanted.global.Response;
 import com.wanted.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +37,14 @@ public class PostApiController {
     public ResponseEntity<Response<Page<PostGetResponse>>> getPage(Pageable pageable) {
 
         Page<PostGetResponse> response = postService.getPostPage(pageable);
+
+        return ResponseEntity.ok(Response.success(response));
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<Response<PostUpdateResponse>> update(@RequestBody PostUpdateRequest requestDto, Authentication authentication, @PathVariable(name = "postId") Long postId) {
+
+        PostUpdateResponse response = postService.updatePost(requestDto, postId, authentication.getName());
 
         return ResponseEntity.ok(Response.success(response));
     }

--- a/src/main/java/com/wanted/controller/PostApiController.java
+++ b/src/main/java/com/wanted/controller/PostApiController.java
@@ -49,5 +49,13 @@ public class PostApiController {
         return ResponseEntity.ok(Response.success(response));
     }
 
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Response<PostDeleteResponse>> delete(Authentication authentication, @PathVariable(name = "postId") Long postId) {
+
+        PostDeleteResponse response = postService.deletePost(postId, authentication.getName());
+
+        return ResponseEntity.ok(Response.success(response));
+    }
+
 
 }

--- a/src/main/java/com/wanted/domain/post/Post.java
+++ b/src/main/java/com/wanted/domain/post/Post.java
@@ -30,4 +30,13 @@ public class Post {
         this.title = title;
         this.body = body;
     }
+
+    public boolean checkUser(User user) {
+        return this.user.getEmail().equals(user.getEmail());
+    }
+
+    public void update(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
 }

--- a/src/main/java/com/wanted/domain/post/dto/PostDeleteResponse.java
+++ b/src/main/java/com/wanted/domain/post/dto/PostDeleteResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.domain.post.dto;
+
+import com.wanted.domain.post.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDeleteResponse {
+    private Long postId;
+    private String title;
+    private String body;
+
+    public static PostDeleteResponse from(Post post) {
+        return PostDeleteResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .body(post.getBody())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/wanted/domain/post/dto/PostUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.wanted.domain.post.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PostUpdateRequest {
+    private String title;
+    private String body;
+}

--- a/src/main/java/com/wanted/domain/post/dto/PostUpdateResponse.java
+++ b/src/main/java/com/wanted/domain/post/dto/PostUpdateResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.domain.post.dto;
+
+import com.wanted.domain.post.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostUpdateResponse {
+    private Long postId;
+    private String title;
+    private String body;
+
+    public static PostUpdateResponse from(Post post) {
+        return PostUpdateResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .body(post.getBody())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "api/v1/posts").authenticated()
                         .requestMatchers(HttpMethod.PUT, "api/v1/posts/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "api/v1/posts/**").authenticated()
                         .anyRequest().permitAll())
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(new CustomAuthenticationEntryPointHandler()))
                 .addFilterBefore(new JwtAuthenticationFilter(secretKey), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/wanted/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/global/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "api/v1/posts").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "api/v1/posts/**").authenticated()
                         .anyRequest().permitAll())
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(new CustomAuthenticationEntryPointHandler()))
                 .addFilterBefore(new JwtAuthenticationFilter(secretKey), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/wanted/global/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 회원을 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    USER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "작성자 본인만 요청할 수 있습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다.");
 
 

--- a/src/main/java/com/wanted/service/PostService.java
+++ b/src/main/java/com/wanted/service/PostService.java
@@ -59,6 +59,20 @@ public class PostService {
         return PostUpdateResponse.from(foundPost);
     }
 
+    public PostDeleteResponse deletePost(Long postId, String email) {
+        User foundUser = validateAndFindUserByEmail(email);
+
+        Post foundPost = validateAndFindPostById(postId);
+
+        if (!foundPost.checkUser(foundUser)) {
+            throw new AppException(ErrorCode.USER_NOT_MATCH);
+        }
+
+        postRepository.delete(foundPost);
+
+        return PostDeleteResponse.from(foundPost);
+    }
+
     private User validateAndFindUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
@@ -68,4 +82,6 @@ public class PostService {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
     }
+
+
 }

--- a/src/main/java/com/wanted/service/PostService.java
+++ b/src/main/java/com/wanted/service/PostService.java
@@ -3,9 +3,7 @@ package com.wanted.service;
 
 import com.wanted.domain.post.Post;
 import com.wanted.domain.post.PostRepository;
-import com.wanted.domain.post.dto.PostCreateRequest;
-import com.wanted.domain.post.dto.PostCreateResponse;
-import com.wanted.domain.post.dto.PostGetResponse;
+import com.wanted.domain.post.dto.*;
 import com.wanted.domain.user.User;
 import com.wanted.domain.user.UserRepository;
 import com.wanted.global.exception.AppException;
@@ -34,22 +32,40 @@ public class PostService {
         return PostCreateResponse.from(savedPost);
     }
 
-    private User validateAndFindUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-    }
+
 
     public PostGetResponse getPost(Long postId) {
         return PostGetResponse.from(validateAndFindPostById(postId));
     }
 
-    private Post validateAndFindPostById(Long postId) {
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
-    }
+
 
     public Page<PostGetResponse> getPostPage(Pageable pageable) {
         return postRepository.findAll(pageable)
                 .map(post -> PostGetResponse.from(post));
+    }
+
+    public PostUpdateResponse updatePost(PostUpdateRequest requestDto, Long postId, String email) {
+        User foundUser = validateAndFindUserByEmail(email);
+
+        Post foundPost = validateAndFindPostById(postId);
+
+        if (!foundPost.checkUser(foundUser)) {
+            throw new AppException(ErrorCode.USER_NOT_MATCH);
+        }
+
+        foundPost.update(requestDto.getTitle(), requestDto.getBody());
+
+        return PostUpdateResponse.from(foundPost);
+    }
+
+    private User validateAndFindUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Post validateAndFindPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND));
     }
 }

--- a/src/test/java/com/wanted/controller/PostApiControllerTest.java
+++ b/src/test/java/com/wanted/controller/PostApiControllerTest.java
@@ -2,15 +2,14 @@ package com.wanted.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wanted.domain.post.dto.PostCreateRequest;
-import com.wanted.domain.post.dto.PostCreateResponse;
-import com.wanted.domain.post.dto.PostGetResponse;
+import com.wanted.domain.post.dto.*;
 import com.wanted.domain.user.dto.UserCreateRequest;
 import com.wanted.domain.user.dto.UserCreateResponse;
 import com.wanted.domain.user.dto.UserLoginRequest;
 import com.wanted.domain.user.dto.UserLoginResponse;
 import com.wanted.global.config.SecurityConfig;
 import com.wanted.global.exception.AppException;
+import com.wanted.global.exception.ErrorCode;
 import com.wanted.global.util.JwtUtil;
 import com.wanted.service.PostService;
 import com.wanted.service.UserService;
@@ -18,6 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -33,13 +35,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.wanted.global.exception.ErrorCode.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -69,6 +71,8 @@ class PostApiControllerTest {
     PostCreateRequest postCreateRequest;
     PostCreateResponse postCreateResponse;
     PostGetResponse postGetResponse;
+    PostUpdateRequest postUpdateRequest;
+    PostUpdateResponse postUpdateResponse;
     Pageable pageable = PageRequest.of(0,20);
 
 
@@ -95,6 +99,17 @@ class PostApiControllerTest {
         postGetResponse = PostGetResponse.builder()
                 .postId(postId)
                 .author(email)
+                .title(title)
+                .body(body)
+                .build();
+
+        postUpdateRequest = PostUpdateRequest.builder()
+                .title(title)
+                .body(body)
+                .build();
+
+        postUpdateResponse = PostUpdateResponse.builder()
+                .postId(postId)
                 .title(title)
                 .body(body)
                 .build();
@@ -221,5 +236,76 @@ class PostApiControllerTest {
                     .andExpect(jsonPath("$.result.content[0].body").value(body));
         }
 
+    }
+
+
+    @Nested
+    @DisplayName("게시글 수정 테스트")
+    class UpdatePost {
+
+        @Test
+        @DisplayName("성공")
+        void updatePost_success() throws Exception {
+
+            given(postService.updatePost(postUpdateRequest, postId, email))
+                    .willReturn(postUpdateResponse);
+
+            mockMvc.perform(put("/api/v1/posts/"+postId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postUpdateRequest)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.message").value("SUCCESS"))
+                    .andExpect(jsonPath("$.result").exists())
+                    .andExpect(jsonPath("$.result.postId").value(postId))
+                    .andExpect(jsonPath("$.result.title").value(title))
+                    .andExpect(jsonPath("$.result.body").value(body));
+        }
+
+        private static Stream<Arguments> updatePostFailScenarios() {
+            return Stream.of(
+                    Arguments.of(USER_NOT_FOUND,404,"가입된 회원을 찾을 수 없습니다."),
+                    Arguments.of(POST_NOT_FOUND,404,"게시글을 찾을 수 없습니다."),
+                    Arguments.of(USER_NOT_MATCH,401,"작성자 본인만 요청할 수 있습니다.")
+            );
+        }
+
+        @DisplayName("실패")
+        @ParameterizedTest
+        @MethodSource("updatePostFailScenarios")
+        void updatePost_fail_exception(ErrorCode errorCode, int responseStatus, String errorMessage) throws Exception {
+            when(postService.updatePost(postUpdateRequest,postId,email))
+                    .thenThrow(new AppException(errorCode));
+
+            mockMvc.perform(put("/api/v1/posts/"+postId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postUpdateRequest)))
+                    .andDo(print())
+                    .andExpect(status().is(responseStatus))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.message").value("ERROR"))
+                    .andExpect(jsonPath("$.result").exists())
+                    .andExpect(jsonPath("$.result").value(errorMessage));
+
+        }
+
+
+        @Test
+        @DisplayName("실패 - jwt 없이 요청 시")
+        void updatePost_error_tokenNotFound() throws Exception {
+
+            mockMvc.perform(put("/api/v1/posts/"+postId)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postCreateRequest)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.message").value("ERROR"))
+                    .andExpect(jsonPath("$.result").exists())
+                    .andExpect(jsonPath("$.result").value("유효한 토큰이 아닙니다."));
+        }
     }
 }

--- a/src/test/java/com/wanted/service/PostServiceTest.java
+++ b/src/test/java/com/wanted/service/PostServiceTest.java
@@ -2,9 +2,7 @@ package com.wanted.service;
 
 import com.wanted.domain.post.Post;
 import com.wanted.domain.post.PostRepository;
-import com.wanted.domain.post.dto.PostCreateRequest;
-import com.wanted.domain.post.dto.PostCreateResponse;
-import com.wanted.domain.post.dto.PostGetResponse;
+import com.wanted.domain.post.dto.*;
 import com.wanted.domain.user.User;
 import com.wanted.domain.user.UserRepository;
 import com.wanted.domain.user.dto.UserCreateRequest;
@@ -61,13 +59,19 @@ class PostServiceTest {
 
 
     PostCreateRequest postCreateRequest;
+    PostUpdateRequest postUpdateRequest;
 
     @BeforeEach
     void setUp() {
-       postCreateRequest = PostCreateRequest.builder()
-               .title(title)
-               .body(body)
-               .build();
+        postCreateRequest = PostCreateRequest.builder()
+                .title(title)
+                .body(body)
+                .build();
+
+        postUpdateRequest = PostUpdateRequest.builder()
+                .title(title)
+                .body(body)
+                .build();
     }
 
     @Nested
@@ -200,6 +204,95 @@ class PostServiceTest {
             verify(postRepository, atLeastOnce()).findAll(pageable);
         }
 
+    }
+
+
+    @Nested
+    @DisplayName("게시글 수정 테스트")
+    class UpdatePost {
+
+        @Test
+        @DisplayName("성공")
+        void updatePost_success() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.of(mockPost));
+            given(mockPost.checkUser(mockUser))
+                    .willReturn(true);
+            given(mockPost.getId())
+                    .willReturn(postId);
+            given(mockPost.getTitle())
+                    .willReturn(title);
+            given(mockPost.getBody())
+                    .willReturn(body);
+
+
+            //when
+            PostUpdateResponse response = postService.updatePost(postUpdateRequest, postId, email);
+
+            //then
+            assertThat(response).isNotNull();
+            assertThat(response.getPostId()).isEqualTo(postId);
+            assertThat(response.getTitle()).isEqualTo(title);
+            assertThat(response.getBody()).isEqualTo(body);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+        }
+
+        @Test
+        @DisplayName("실패 - 가입된 회원이 아닌 경우 예외 발생")
+        void updatePost_fail_userNotFound() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.empty());
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.updatePost(postUpdateRequest, postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_FOUND);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+        }
+
+        @Test
+        @DisplayName("실패 - postId에 해당하는 게시글이 존재하지 않을 시 예외 발생")
+        void updatePost_fail_postNotFound() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.empty());
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.updatePost(postUpdateRequest, postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(POST_NOT_FOUND);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+        }
+
+        @Test
+        @DisplayName("실패 - 수정 요청자와 작성자가 일치하지 않는 경우 예외 발생")
+        void updatePost_fail_userNotMatch() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.of(mockPost));
+            given(mockPost.checkUser(mockUser))
+                    .willReturn(false);
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.updatePost(postUpdateRequest, postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_MATCH);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+        }
     }
 
 

--- a/src/test/java/com/wanted/service/PostServiceTest.java
+++ b/src/test/java/com/wanted/service/PostServiceTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
@@ -55,11 +56,12 @@ class PostServiceTest {
     String email = "email";
     Long postId = 1L;
     Long userId = 1L;
-    Pageable pageable = PageRequest.of(0,20);
+    Pageable pageable = PageRequest.of(0, 20);
 
 
     PostCreateRequest postCreateRequest;
     PostUpdateRequest postUpdateRequest;
+    PostDeleteResponse postDeleteResponse;
 
     @BeforeEach
     void setUp() {
@@ -69,6 +71,12 @@ class PostServiceTest {
                 .build();
 
         postUpdateRequest = PostUpdateRequest.builder()
+                .title(title)
+                .body(body)
+                .build();
+
+        postDeleteResponse = PostDeleteResponse.builder()
+                .postId(postId)
                 .title(title)
                 .body(body)
                 .build();
@@ -99,7 +107,7 @@ class PostServiceTest {
 
 
             //when
-            PostCreateResponse response = postService.createPost(postCreateRequest,email);
+            PostCreateResponse response = postService.createPost(postCreateRequest, email);
 
             //then
             assertThat(response).isNotNull();
@@ -119,7 +127,7 @@ class PostServiceTest {
                     .willReturn(Optional.empty());
 
             //when
-            AppException appException = assertThrows(AppException.class, () -> postService.createPost(postCreateRequest,email));
+            AppException appException = assertThrows(AppException.class, () -> postService.createPost(postCreateRequest, email));
 
             //then
             assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_FOUND);
@@ -292,6 +300,99 @@ class PostServiceTest {
             assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_MATCH);
             verify(userRepository, atLeastOnce()).findByEmail(email);
             verify(postRepository, atLeastOnce()).findById(postId);
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제 테스트")
+    class DeletePost {
+
+        @Test
+        @DisplayName("성공")
+        void deletePost_success() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.of(mockPost));
+            given(mockPost.checkUser(mockUser))
+                    .willReturn(true);
+            willDoNothing().given(postRepository)
+                    .delete(mockPost);
+            given(mockPost.getId())
+                    .willReturn(postId);
+            given(mockPost.getTitle())
+                    .willReturn(title);
+            given(mockPost.getBody())
+                    .willReturn(body);
+
+
+            //when
+            PostDeleteResponse response = postService.deletePost(postId, email);
+
+            //then
+            assertThat(response).isNotNull();
+            assertThat(response.getPostId()).isEqualTo(postId);
+            assertThat(response.getTitle()).isEqualTo(title);
+            assertThat(response.getBody()).isEqualTo(body);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+            verify(postRepository, atLeastOnce()).delete(mockPost);
+        }
+
+        @Test
+        @DisplayName("실패 - 가입된 회원이 아닌 경우 예외 발생")
+        void deletePost_fail_userNotFound() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.empty());
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.deletePost(postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_FOUND);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+        }
+
+        @Test
+        @DisplayName("실패 - postId에 해당하는 게시글이 존재하지 않을 시 예외 발생")
+        void deletePost_fail_postNotFound() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.empty());
+
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.deletePost(postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(POST_NOT_FOUND);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+        }
+
+        @Test
+        @DisplayName("실패 - 수정 요청자와 작성자가 일치하지 않는 경우 예외 발생")
+        void deletePost_fail_userNotMatch() {
+            //given
+            given(userRepository.findByEmail(email))
+                    .willReturn(Optional.of(mockUser));
+            given(postRepository.findById(postId))
+                    .willReturn(Optional.of(mockPost));
+            given(mockPost.checkUser(mockUser))
+                    .willReturn(false);
+
+            //when
+            AppException appException = assertThrows(AppException.class, () -> postService.deletePost(postId, email));
+
+            //then
+            assertThat(appException.getErrorCode()).isEqualTo(USER_NOT_MATCH);
+            verify(userRepository, atLeastOnce()).findByEmail(email);
+            verify(postRepository, atLeastOnce()).findById(postId);
+            verify(mockPost, atLeastOnce()).checkUser(mockUser);
         }
     }
 


### PR DESCRIPTION
관련 이슈 : #11 

게시글 수정과 삭제는 본인만 가능합니다.
가입되지 않은 사용자이거나 유효하지 않는 jwt를 전달하는 경우 예외 처리됩니다.
수정 및 삭제하려는 postId의 게시글이 존재하지 않는 경우 예외 처리됩니다.
